### PR TITLE
feat: Implement aggregator for getting all LLMs of configured providers from a single endpoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ COPY logger ./logger
 COPY gateway ./gateway
 COPY otel ./otel
 COPY cmd ./cmd
+COPY api ./api
 
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-w -s" -o inference-gateway ./cmd/gateway/main.go
 

--- a/api/routes.go
+++ b/api/routes.go
@@ -64,7 +64,7 @@ func fetchModels(url string, provider string, wg *sync.WaitGroup, ch chan<- Mode
 	defer wg.Done()
 	resp, err := http.Get(url)
 	if err != nil {
-		ch <- ModelResponse{Provider: provider, Models: nil}
+		ch <- ModelResponse{Provider: provider, Models: []interface{}{}}
 		return
 	}
 	defer resp.Body.Close()

--- a/api/routes.go
+++ b/api/routes.go
@@ -1,0 +1,75 @@
+package api
+
+import (
+	"encoding/json"
+	"net/http"
+	"sync"
+)
+
+type ModelResponse struct {
+	Provider string        `json:"provider"`
+	Models   []interface{} `json:"models"`
+}
+
+func fetchModels(url string, provider string, wg *sync.WaitGroup, ch chan<- ModelResponse) {
+	defer wg.Done()
+	resp, err := http.Get(url)
+	if err != nil {
+		ch <- ModelResponse{Provider: provider, Models: nil}
+		return
+	}
+	defer resp.Body.Close()
+
+	if provider == "Google" {
+		var response struct {
+			Models []interface{} `json:"models"`
+		}
+		if err = json.NewDecoder(resp.Body).Decode(&response); err != nil {
+			ch <- ModelResponse{Provider: provider, Models: nil}
+			return
+		}
+		ch <- ModelResponse{Provider: provider, Models: response.Models}
+		return
+	}
+
+	var response struct {
+		Object string        `json:"object"`
+		Data   []interface{} `json:"data"`
+	}
+	if err = json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		ch <- ModelResponse{Provider: provider, Models: nil}
+		return
+	}
+	ch <- ModelResponse{Provider: provider, Models: response.Data}
+}
+
+func FetchAllModelsHandler(w http.ResponseWriter, r *http.Request) {
+	var wg sync.WaitGroup
+	modelProviders := map[string]string{
+		"Ollama":     "http://localhost:8080/llms/ollama/v1/models",
+		"Groq":       "http://localhost:8080/llms/groq/openai/v1/models",
+		"OpenAI":     "http://localhost:8080/llms/openai/v1/models",
+		"Google":     "http://localhost:8080/llms/google/v1beta/models",
+		"Cloudflare": "http://localhost:8080/llms/cloudflare/ai/models",
+	}
+
+	ch := make(chan ModelResponse, len(modelProviders))
+	for provider, url := range modelProviders {
+		wg.Add(1)
+		go fetchModels(url, provider, &wg, ch)
+	}
+
+	wg.Wait()
+	close(ch)
+
+	var allModels []ModelResponse
+	for model := range ch {
+		allModels = append(allModels, model)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(allModels); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}

--- a/api/routes.go
+++ b/api/routes.go
@@ -6,9 +6,54 @@ import (
 	"sync"
 )
 
+type Router interface {
+	FetchAllModelsHandler(w http.ResponseWriter, r *http.Request)
+}
+
+type RouterImpl struct{}
+
+func (router *RouterImpl) Healthcheck(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(map[string]string{"status": "ok"}); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
+}
+
 type ModelResponse struct {
 	Provider string        `json:"provider"`
 	Models   []interface{} `json:"models"`
+}
+
+func (router *RouterImpl) FetchAllModelsHandler(w http.ResponseWriter, r *http.Request) {
+	var wg sync.WaitGroup
+	modelProviders := map[string]string{
+		"Ollama":     "http://localhost:8080/llms/ollama/v1/models",
+		"Groq":       "http://localhost:8080/llms/groq/openai/v1/models",
+		"OpenAI":     "http://localhost:8080/llms/openai/v1/models",
+		"Google":     "http://localhost:8080/llms/google/v1beta/models",
+		"Cloudflare": "http://localhost:8080/llms/cloudflare/ai/models",
+	}
+
+	ch := make(chan ModelResponse, len(modelProviders))
+	for provider, url := range modelProviders {
+		wg.Add(1)
+		go fetchModels(url, provider, &wg, ch)
+	}
+
+	wg.Wait()
+	close(ch)
+
+	var allModels []ModelResponse
+	for model := range ch {
+		allModels = append(allModels, model)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(allModels); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 }
 
 func fetchModels(url string, provider string, wg *sync.WaitGroup, ch chan<- ModelResponse) {
@@ -41,35 +86,4 @@ func fetchModels(url string, provider string, wg *sync.WaitGroup, ch chan<- Mode
 		return
 	}
 	ch <- ModelResponse{Provider: provider, Models: response.Data}
-}
-
-func FetchAllModelsHandler(w http.ResponseWriter, r *http.Request) {
-	var wg sync.WaitGroup
-	modelProviders := map[string]string{
-		"Ollama":     "http://localhost:8080/llms/ollama/v1/models",
-		"Groq":       "http://localhost:8080/llms/groq/openai/v1/models",
-		"OpenAI":     "http://localhost:8080/llms/openai/v1/models",
-		"Google":     "http://localhost:8080/llms/google/v1beta/models",
-		"Cloudflare": "http://localhost:8080/llms/cloudflare/ai/models",
-	}
-
-	ch := make(chan ModelResponse, len(modelProviders))
-	for provider, url := range modelProviders {
-		wg.Add(1)
-		go fetchModels(url, provider, &wg, ch)
-	}
-
-	wg.Wait()
-	close(ch)
-
-	var allModels []ModelResponse
-	for model := range ch {
-		allModels = append(allModels, model)
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(allModels); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
-	}
 }

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -58,7 +58,9 @@ func main() {
 	http.HandleFunc("/llms/google/", gateway.Create(cfg.GoogleAIStudioURL, cfg.GoogleAIStudioKey, "/llms/google/", tp, cfg.EnableTelemetry, logger))
 	http.HandleFunc("/llms/cloudflare/", gateway.Create(cfg.CloudflareAPIURL, cfg.CloudflareAPIKey, "/llms/cloudflare/", tp, cfg.EnableTelemetry, logger))
 
-	api := &api.RouterImpl{}
+	api := &api.RouterImpl{
+		Logger: logger,
+	}
 	http.HandleFunc("/llms", api.FetchAllModelsHandler)
 	http.HandleFunc("/health", api.Healthcheck)
 

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -2,10 +2,12 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"log"
 	"net/http"
 	"os"
 	"os/signal"
+	"sync"
 	"syscall"
 	"time"
 
@@ -57,6 +59,7 @@ func main() {
 	http.HandleFunc("/llms/google/", gateway.Create(cfg.GoogleAIStudioURL, cfg.GoogleAIStudioKey, "/llms/google/", tp, cfg.EnableTelemetry, logger))
 	http.HandleFunc("/llms/cloudflare/", gateway.Create(cfg.CloudflareAPIURL, cfg.CloudflareAPIKey, "/llms/cloudflare/", tp, cfg.EnableTelemetry, logger))
 
+	http.HandleFunc("/llms", fetchAllModelsHandler)
 	http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -104,5 +107,73 @@ func main() {
 		logger.Error("Server Shutdown error", err)
 	} else {
 		logger.Info("Server gracefully stopped")
+	}
+}
+
+type ModelResponse struct {
+	Provider string        `json:"provider"`
+	Models   []interface{} `json:"models"`
+}
+
+func fetchModels(url string, provider string, wg *sync.WaitGroup, ch chan<- ModelResponse) {
+	defer wg.Done()
+	resp, err := http.Get(url)
+	if err != nil {
+		ch <- ModelResponse{Provider: provider, Models: nil}
+		return
+	}
+	defer resp.Body.Close()
+
+	if provider == "Google" {
+		var response struct {
+			Models []interface{} `json:"models"`
+		}
+		if err = json.NewDecoder(resp.Body).Decode(&response); err != nil {
+			ch <- ModelResponse{Provider: provider, Models: nil}
+			return
+		}
+		ch <- ModelResponse{Provider: provider, Models: response.Models}
+		return
+	}
+
+	var response struct {
+		Object string        `json:"object"`
+		Data   []interface{} `json:"data"`
+	}
+	if err = json.NewDecoder(resp.Body).Decode(&response); err != nil {
+		ch <- ModelResponse{Provider: provider, Models: nil}
+		return
+	}
+	ch <- ModelResponse{Provider: provider, Models: response.Data}
+}
+
+func fetchAllModelsHandler(w http.ResponseWriter, r *http.Request) {
+	var wg sync.WaitGroup
+	modelProviders := map[string]string{
+		"Ollama":     "http://localhost:8080/llms/ollama/v1/models",
+		"Groq":       "http://localhost:8080/llms/groq/openai/v1/models",
+		"OpenAI":     "http://localhost:8080/llms/openai/v1/models",
+		"Google":     "http://localhost:8080/llms/google/v1beta/models",
+		"Cloudflare": "http://localhost:8080/llms/cloudflare/ai/models",
+	}
+
+	ch := make(chan ModelResponse, len(modelProviders))
+	for provider, url := range modelProviders {
+		wg.Add(1)
+		go fetchModels(url, provider, &wg, ch)
+	}
+
+	wg.Wait()
+	close(ch)
+
+	var allModels []ModelResponse
+	for model := range ch {
+		allModels = append(allModels, model)
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(allModels); err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
 	}
 }

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -2,15 +2,14 @@ package main
 
 import (
 	"context"
-	"encoding/json"
 	"log"
 	"net/http"
 	"os"
 	"os/signal"
-	"sync"
 	"syscall"
 	"time"
 
+	api "github.com/edenreich/inference-gateway/api"
 	config "github.com/edenreich/inference-gateway/config"
 	gateway "github.com/edenreich/inference-gateway/gateway"
 	l "github.com/edenreich/inference-gateway/logger"
@@ -59,7 +58,7 @@ func main() {
 	http.HandleFunc("/llms/google/", gateway.Create(cfg.GoogleAIStudioURL, cfg.GoogleAIStudioKey, "/llms/google/", tp, cfg.EnableTelemetry, logger))
 	http.HandleFunc("/llms/cloudflare/", gateway.Create(cfg.CloudflareAPIURL, cfg.CloudflareAPIKey, "/llms/cloudflare/", tp, cfg.EnableTelemetry, logger))
 
-	http.HandleFunc("/llms", fetchAllModelsHandler)
+	http.HandleFunc("/llms", api.FetchAllModelsHandler)
 	http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
@@ -107,73 +106,5 @@ func main() {
 		logger.Error("Server Shutdown error", err)
 	} else {
 		logger.Info("Server gracefully stopped")
-	}
-}
-
-type ModelResponse struct {
-	Provider string        `json:"provider"`
-	Models   []interface{} `json:"models"`
-}
-
-func fetchModels(url string, provider string, wg *sync.WaitGroup, ch chan<- ModelResponse) {
-	defer wg.Done()
-	resp, err := http.Get(url)
-	if err != nil {
-		ch <- ModelResponse{Provider: provider, Models: nil}
-		return
-	}
-	defer resp.Body.Close()
-
-	if provider == "Google" {
-		var response struct {
-			Models []interface{} `json:"models"`
-		}
-		if err = json.NewDecoder(resp.Body).Decode(&response); err != nil {
-			ch <- ModelResponse{Provider: provider, Models: nil}
-			return
-		}
-		ch <- ModelResponse{Provider: provider, Models: response.Models}
-		return
-	}
-
-	var response struct {
-		Object string        `json:"object"`
-		Data   []interface{} `json:"data"`
-	}
-	if err = json.NewDecoder(resp.Body).Decode(&response); err != nil {
-		ch <- ModelResponse{Provider: provider, Models: nil}
-		return
-	}
-	ch <- ModelResponse{Provider: provider, Models: response.Data}
-}
-
-func fetchAllModelsHandler(w http.ResponseWriter, r *http.Request) {
-	var wg sync.WaitGroup
-	modelProviders := map[string]string{
-		"Ollama":     "http://localhost:8080/llms/ollama/v1/models",
-		"Groq":       "http://localhost:8080/llms/groq/openai/v1/models",
-		"OpenAI":     "http://localhost:8080/llms/openai/v1/models",
-		"Google":     "http://localhost:8080/llms/google/v1beta/models",
-		"Cloudflare": "http://localhost:8080/llms/cloudflare/ai/models",
-	}
-
-	ch := make(chan ModelResponse, len(modelProviders))
-	for provider, url := range modelProviders {
-		wg.Add(1)
-		go fetchModels(url, provider, &wg, ch)
-	}
-
-	wg.Wait()
-	close(ch)
-
-	var allModels []ModelResponse
-	for model := range ch {
-		allModels = append(allModels, model)
-	}
-
-	w.Header().Set("Content-Type", "application/json")
-	if err := json.NewEncoder(w).Encode(allModels); err != nil {
-		http.Error(w, err.Error(), http.StatusInternalServerError)
-		return
 	}
 }

--- a/cmd/gateway/main.go
+++ b/cmd/gateway/main.go
@@ -58,10 +58,9 @@ func main() {
 	http.HandleFunc("/llms/google/", gateway.Create(cfg.GoogleAIStudioURL, cfg.GoogleAIStudioKey, "/llms/google/", tp, cfg.EnableTelemetry, logger))
 	http.HandleFunc("/llms/cloudflare/", gateway.Create(cfg.CloudflareAPIURL, cfg.CloudflareAPIKey, "/llms/cloudflare/", tp, cfg.EnableTelemetry, logger))
 
+	api := &api.RouterImpl{}
 	http.HandleFunc("/llms", api.FetchAllModelsHandler)
-	http.HandleFunc("/health", func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusOK)
-	})
+	http.HandleFunc("/health", api.Healthcheck)
 
 	server := &http.Server{
 		Addr:         cfg.ServerHost + ":" + cfg.ServerPort,

--- a/examples/rest-endpoints/README.md
+++ b/examples/rest-endpoints/README.md
@@ -6,6 +6,7 @@ Assuming you've deployed the Inference Gateway, you can interact with the langua
 
 | Description            | Curl Command                                                   |
 | ---------------------- | -------------------------------------------------------------- |
+| List all models        | `curl -X GET http://localhost:8080/llms`                       |
 | List Ollama models     | `curl -X GET http://localhost:8080/llms/ollama/v1/models`      |
 | List Groq models       | `curl -X GET http://localhost:8080/llms/groq/openai/v1/models` |
 | List OpenAI models     | `curl -X GET http://localhost:8080/llms/openai/v1/models`      |

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -104,11 +104,11 @@ components:
         provider:
           type: string
           enum:
-            - groq
-            - openai
-            - cloudflare
-            - ollama
-            - google
+            - Ollama
+            - Groq
+            - OpenAI
+            - Google
+            - Cloudflare
         models:
           type: array
           items:

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -7,6 +7,18 @@ info:
 servers:
   - url: http://localhost:8080
 paths:
+  /llms:
+    get:
+      summary: List all language models
+      responses:
+        "200":
+          description: A list of models
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/ProviderModels"
   /llms/{provider}/v1/models:
     get:
       summary: List models of a specific provider
@@ -86,3 +98,27 @@ components:
           type: string
         created:
           type: integer
+    ProviderModels:
+      type: object
+      properties:
+        provider:
+          type: string
+          enum:
+            - groq
+            - openai
+            - cloudflare
+            - ollama
+            - google
+        models:
+          type: array
+          items:
+            type: object
+            properties:
+              id:
+                type: string
+              object:
+                type: string
+              owned_by:
+                type: string
+              created:
+                type: integer

--- a/openapi.yaml
+++ b/openapi.yaml
@@ -29,11 +29,11 @@ paths:
           schema:
             type: string
             enum:
+              - ollama
               - groq
               - openai
-              - cloudflare
-              - ollama
               - google
+              - cloudflare
       responses:
         "200":
           description: A list of models
@@ -53,11 +53,11 @@ paths:
           schema:
             type: string
             enum:
+              - ollama
               - groq
               - openai
-              - cloudflare
-              - ollama
               - google
+              - cloudflare
       requestBody:
         required: true
         content:


### PR DESCRIPTION
## Summary

It's easier to have a single endpoint with expected structure of all different LLMs.

Later it would be easy to build an SDK around it.